### PR TITLE
Expand payload limit to 50 MB

### DIFF
--- a/config/routes.ts
+++ b/config/routes.ts
@@ -28,7 +28,7 @@ function resolvePath(sourceDir: string, filename: string) {
 
 const router = express.Router()
 
-router.use(bodyParser.json())
+router.use(bodyParser.json({ limit: '50mb' }))
 
 router
   .route('/data')


### PR DESCRIPTION
The max payload size for body-parser defaults to 100 KB, but this is too small to receive the whole texts.

This change expands the limit to 50 MB.